### PR TITLE
Adicionar dashboard NutriTrack IA com registro por foto (IA), peso, água e relatórios

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,14 +2,116 @@
 <html lang="pt-BR">
 <head>
     <meta charset="UTF-8">
-    <title>Chat Flow</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>NutriTrack IA</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <div class="chat">
-        <div class="messages" id="messages"></div>
-        <button id="nextButton">Próxima Mensagem</button>
-    </div>
+    <main class="container">
+        <header class="hero">
+            <h1>NutriTrack IA</h1>
+            <p>Registre refeições por foto com IA, peso e ingestão de água em uma única planilha digital.</p>
+        </header>
+
+        <section class="card grid-two">
+            <div>
+                <h2>Configuração de IA</h2>
+                <label for="apiKey">OpenAI API Key (opcional para usar análise por foto)</label>
+                <input id="apiKey" type="password" placeholder="sk-..." autocomplete="off">
+                <small>Guardada apenas no navegador (localStorage) e usada para estimar calorias a partir da imagem.</small>
+            </div>
+            <div>
+                <h2>Registro de Refeição</h2>
+                <form id="mealForm" class="stack">
+                    <label for="mealDate">Data e hora</label>
+                    <input id="mealDate" type="datetime-local" required>
+
+                    <label for="mealPhoto">Foto da refeição</label>
+                    <input id="mealPhoto" type="file" accept="image/*">
+
+                    <label for="manualCalories">Calorias (manual, opcional)</label>
+                    <input id="manualCalories" type="number" min="0" step="1" placeholder="Ex.: 520">
+
+                    <button type="button" id="analyzeButton">Analisar foto com IA</button>
+                    <button type="submit">Salvar refeição</button>
+                </form>
+                <p id="analysisResult" class="info"></p>
+            </div>
+        </section>
+
+        <section class="card grid-two">
+            <div>
+                <h2>Registro de Peso</h2>
+                <form id="weightForm" class="stack">
+                    <label for="weightDate">Data e hora</label>
+                    <input id="weightDate" type="datetime-local" required>
+
+                    <label for="weightValue">Peso (kg)</label>
+                    <input id="weightValue" type="number" min="1" step="0.1" placeholder="Ex.: 78.4" required>
+
+                    <button type="submit">Salvar peso</button>
+                </form>
+            </div>
+            <div>
+                <h2>Registro de Água</h2>
+                <form id="waterForm" class="stack">
+                    <label for="waterDate">Data e hora</label>
+                    <input id="waterDate" type="datetime-local" required>
+
+                    <label for="waterAmount">Quantidade (ml)</label>
+                    <input id="waterAmount" type="number" min="1" step="10" placeholder="Ex.: 300" required>
+
+                    <button type="submit">Salvar água</button>
+                </form>
+            </div>
+        </section>
+
+        <section class="card">
+            <h2>Relatórios</h2>
+            <div class="stats" id="stats"></div>
+            <div class="reports grid-three">
+                <article>
+                    <h3>Calorias por dia (últimos 7 dias)</h3>
+                    <div id="dailyCalories" class="bars"></div>
+                </article>
+                <article>
+                    <h3>Calorias por semana (últimas 8 semanas)</h3>
+                    <div id="weeklyCalories" class="bars"></div>
+                </article>
+                <article>
+                    <h3>Calorias por mês (últimos 6 meses)</h3>
+                    <div id="monthlyCalories" class="bars"></div>
+                </article>
+            </div>
+
+            <article>
+                <h3>Progresso de peso</h3>
+                <div id="weightProgress" class="bars"></div>
+            </article>
+        </section>
+
+        <section class="card">
+            <h2>Planilha Única (Banco de dados local)</h2>
+            <p class="muted">Todos os registros ficam nesta tabela única e são persistidos no navegador.</p>
+            <div class="table-wrapper">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Data/Hora</th>
+                            <th>Tipo</th>
+                            <th>Calorias</th>
+                            <th>Peso (kg)</th>
+                            <th>Água (ml)</th>
+                            <th>Observação</th>
+                            <th>Ação</th>
+                        </tr>
+                    </thead>
+                    <tbody id="recordsTable"></tbody>
+                </table>
+            </div>
+        </section>
+    </main>
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,31 +1,371 @@
-const messages = [
-    { text: 'Olá! Bem-vindo ao chat.', sender: 'sender' },
-    { text: 'Como você está hoje?', sender: 'sender' },
-    { text: 'Estou ótimo, obrigado!', sender: 'user' },
-    { text: 'Que bom saber. Podemos continuar nossa conversa.', sender: 'sender' },
-    { text: 'Claro, até a próxima!', sender: 'user' }
-];
+const STORAGE_KEY = 'nutriTrackRecords';
+const API_KEY_STORAGE = 'nutriTrackApiKey';
 
-let index = 0;
-const messagesContainer = document.getElementById('messages');
-const nextButton = document.getElementById('nextButton');
+const mealForm = document.getElementById('mealForm');
+const weightForm = document.getElementById('weightForm');
+const waterForm = document.getElementById('waterForm');
+const recordsTable = document.getElementById('recordsTable');
+const statsContainer = document.getElementById('stats');
+const analysisResult = document.getElementById('analysisResult');
+const apiKeyInput = document.getElementById('apiKey');
 
-function showNextMessage() {
-    if (index < messages.length) {
-        const msg = messages[index];
-        const div = document.createElement('div');
-        div.classList.add('message', msg.sender);
-        div.textContent = msg.text;
-        messagesContainer.appendChild(div);
-        messagesContainer.scrollTop = messagesContainer.scrollHeight;
-        index++;
-        if (index === messages.length) {
-            nextButton.disabled = true;
-        }
+const analyzeButton = document.getElementById('analyzeButton');
+const mealPhotoInput = document.getElementById('mealPhoto');
+const manualCaloriesInput = document.getElementById('manualCalories');
+
+const dailyCalories = document.getElementById('dailyCalories');
+const weeklyCalories = document.getElementById('weeklyCalories');
+const monthlyCalories = document.getElementById('monthlyCalories');
+const weightProgress = document.getElementById('weightProgress');
+
+let records = loadRecords();
+apiKeyInput.value = localStorage.getItem(API_KEY_STORAGE) || '';
+setDefaultDates();
+renderAll();
+
+apiKeyInput.addEventListener('change', () => {
+    localStorage.setItem(API_KEY_STORAGE, apiKeyInput.value.trim());
+});
+
+analyzeButton.addEventListener('click', analyzeMealPhoto);
+mealForm.addEventListener('submit', handleMealSubmit);
+weightForm.addEventListener('submit', handleWeightSubmit);
+waterForm.addEventListener('submit', handleWaterSubmit);
+recordsTable.addEventListener('click', handleDelete);
+
+function setDefaultDates() {
+    const now = new Date();
+    const local = now.toISOString().slice(0, 16);
+    document.getElementById('mealDate').value = local;
+    document.getElementById('weightDate').value = local;
+    document.getElementById('waterDate').value = local;
+}
+
+function loadRecords() {
+    try {
+        return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+    } catch {
+        return [];
     }
 }
 
-nextButton.addEventListener('click', showNextMessage);
+function saveRecords() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(records));
+}
 
-// show first message immediately
-showNextMessage();
+async function analyzeMealPhoto() {
+    const file = mealPhotoInput.files[0];
+    const apiKey = apiKeyInput.value.trim();
+
+    if (!file) {
+        analysisResult.textContent = 'Selecione uma foto antes de analisar.';
+        return;
+    }
+    if (!apiKey) {
+        analysisResult.textContent = 'Informe a API key para usar análise por IA.';
+        return;
+    }
+
+    analysisResult.textContent = 'Analisando imagem com IA...';
+
+    try {
+        const base64 = await toBase64(file);
+        const response = await fetch('https://api.openai.com/v1/responses', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${apiKey}`,
+            },
+            body: JSON.stringify({
+                model: 'gpt-4.1-mini',
+                input: [
+                    {
+                        role: 'user',
+                        content: [
+                            {
+                                type: 'input_text',
+                                text: 'Analise a refeição na imagem e responda APENAS com um número inteiro representando calorias estimadas totais.',
+                            },
+                            {
+                                type: 'input_image',
+                                image_url: base64,
+                            },
+                        ],
+                    },
+                ],
+            }),
+        });
+
+        if (!response.ok) {
+            throw new Error('Falha ao chamar API de IA.');
+        }
+
+        const data = await response.json();
+        const rawText = data.output_text || '';
+        const calories = Number((rawText.match(/\d+/) || [])[0]);
+
+        if (!calories) {
+            throw new Error('A IA não retornou calorias válidas.');
+        }
+
+        manualCaloriesInput.value = calories;
+        analysisResult.textContent = `Estimativa de calorias: ${calories} kcal`;
+    } catch (error) {
+        analysisResult.textContent = `Erro: ${error.message}`;
+    }
+}
+
+function handleMealSubmit(event) {
+    event.preventDefault();
+
+    const date = document.getElementById('mealDate').value;
+    const calories = Number(manualCaloriesInput.value);
+
+    if (!date || !calories) {
+        analysisResult.textContent = 'Informe data e calorias (manual ou via IA).';
+        return;
+    }
+
+    records.push({
+        id: crypto.randomUUID(),
+        datetime: new Date(date).toISOString(),
+        type: 'meal',
+        calories,
+        weightKg: null,
+        waterMl: null,
+        note: mealPhotoInput.files[0] ? `Foto: ${mealPhotoInput.files[0].name}` : 'Inserção manual',
+    });
+
+    mealForm.reset();
+    setDefaultDates();
+    analysisResult.textContent = 'Refeição salva com sucesso.';
+    persistAndRender();
+}
+
+function handleWeightSubmit(event) {
+    event.preventDefault();
+
+    const date = document.getElementById('weightDate').value;
+    const weight = Number(document.getElementById('weightValue').value);
+
+    if (!date || !weight) {
+        return;
+    }
+
+    records.push({
+        id: crypto.randomUUID(),
+        datetime: new Date(date).toISOString(),
+        type: 'weight',
+        calories: null,
+        weightKg: weight,
+        waterMl: null,
+        note: 'Registro de peso',
+    });
+
+    weightForm.reset();
+    setDefaultDates();
+    persistAndRender();
+}
+
+function handleWaterSubmit(event) {
+    event.preventDefault();
+
+    const date = document.getElementById('waterDate').value;
+    const water = Number(document.getElementById('waterAmount').value);
+
+    if (!date || !water) {
+        return;
+    }
+
+    records.push({
+        id: crypto.randomUUID(),
+        datetime: new Date(date).toISOString(),
+        type: 'water',
+        calories: null,
+        weightKg: null,
+        waterMl: water,
+        note: 'Registro de água',
+    });
+
+    waterForm.reset();
+    setDefaultDates();
+    persistAndRender();
+}
+
+function handleDelete(event) {
+    if (!event.target.classList.contains('delete-btn')) {
+        return;
+    }
+    const id = event.target.dataset.id;
+    records = records.filter((record) => record.id !== id);
+    persistAndRender();
+}
+
+function persistAndRender() {
+    records.sort((a, b) => new Date(b.datetime) - new Date(a.datetime));
+    saveRecords();
+    renderAll();
+}
+
+function renderAll() {
+    renderTable();
+    renderStats();
+    renderReports();
+}
+
+function renderTable() {
+    recordsTable.innerHTML = '';
+
+    for (const record of records) {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+            <td>${formatDateTime(record.datetime)}</td>
+            <td>${labelType(record.type)}</td>
+            <td>${record.calories ?? '-'}</td>
+            <td>${record.weightKg ?? '-'}</td>
+            <td>${record.waterMl ?? '-'}</td>
+            <td>${record.note || '-'}</td>
+            <td><button class="delete-btn" data-id="${record.id}">Excluir</button></td>
+        `;
+        recordsTable.appendChild(tr);
+    }
+}
+
+function renderStats() {
+    const meals = records.filter((record) => record.type === 'meal');
+    const weights = records.filter((record) => record.type === 'weight');
+    const waters = records.filter((record) => record.type === 'water');
+
+    const totalCalories = meals.reduce((sum, item) => sum + (item.calories || 0), 0);
+    const totalWater = waters.reduce((sum, item) => sum + (item.waterMl || 0), 0);
+
+    const latestWeight = weights.length ? weights.slice().sort((a, b) => new Date(b.datetime) - new Date(a.datetime))[0].weightKg : null;
+
+    statsContainer.innerHTML = `
+        <div class="stat-box"><span>Registros totais</span><strong>${records.length}</strong></div>
+        <div class="stat-box"><span>Calorias totais</span><strong>${totalCalories} kcal</strong></div>
+        <div class="stat-box"><span>Água total</span><strong>${totalWater} ml</strong></div>
+        <div class="stat-box"><span>Último peso</span><strong>${latestWeight ? `${latestWeight} kg` : '-'}</strong></div>
+    `;
+}
+
+function renderReports() {
+    renderBars(dailyCalories, aggregateCaloriesByPeriod('day', 7));
+    renderBars(weeklyCalories, aggregateCaloriesByPeriod('week', 8));
+    renderBars(monthlyCalories, aggregateCaloriesByPeriod('month', 6));
+    renderBars(weightProgress, weightSeries(8), 'kg');
+}
+
+function aggregateCaloriesByPeriod(period, count) {
+    const meals = records.filter((record) => record.type === 'meal');
+    const grouped = new Map();
+
+    for (const meal of meals) {
+        const date = new Date(meal.datetime);
+        const key = periodKey(date, period);
+        grouped.set(key, (grouped.get(key) || 0) + meal.calories);
+    }
+
+    return buildRecentLabels(period, count).map((label) => ({
+        label,
+        value: grouped.get(label) || 0,
+    }));
+}
+
+function weightSeries(limit) {
+    const points = records
+        .filter((record) => record.type === 'weight')
+        .sort((a, b) => new Date(a.datetime) - new Date(b.datetime))
+        .slice(-limit)
+        .map((record) => ({
+            label: shortDate(record.datetime),
+            value: record.weightKg,
+        }));
+
+    return points.length ? points : [{ label: 'Sem dados', value: 0 }];
+}
+
+function renderBars(container, data, unit = 'kcal') {
+    container.innerHTML = '';
+    const max = Math.max(...data.map((item) => item.value), 1);
+
+    data.forEach((item) => {
+        const row = document.createElement('div');
+        row.className = 'bar-row';
+        row.innerHTML = `
+            <span>${item.label}</span>
+            <div class="bar"><div class="bar-fill" style="width: ${(item.value / max) * 100}%"></div></div>
+            <strong>${Math.round(item.value)}${unit === 'kg' ? '' : ''} ${unit}</strong>
+        `;
+        container.appendChild(row);
+    });
+}
+
+function periodKey(date, period) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+
+    if (period === 'day') {
+        return `${year}-${month}-${day}`;
+    }
+
+    if (period === 'month') {
+        return `${year}-${month}`;
+    }
+
+    const week = getWeekNumber(date);
+    return `${year}-W${String(week).padStart(2, '0')}`;
+}
+
+function buildRecentLabels(period, count) {
+    const labels = [];
+    const now = new Date();
+
+    for (let i = count - 1; i >= 0; i--) {
+        const date = new Date(now);
+        if (period === 'day') {
+            date.setDate(now.getDate() - i);
+        } else if (period === 'month') {
+            date.setMonth(now.getMonth() - i);
+        } else {
+            date.setDate(now.getDate() - i * 7);
+        }
+        labels.push(periodKey(date, period));
+    }
+
+    return labels;
+}
+
+function getWeekNumber(date) {
+    const temp = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+    const dayNum = temp.getUTCDay() || 7;
+    temp.setUTCDate(temp.getUTCDate() + 4 - dayNum);
+    const yearStart = new Date(Date.UTC(temp.getUTCFullYear(), 0, 1));
+    return Math.ceil((((temp - yearStart) / 86400000) + 1) / 7);
+}
+
+function formatDateTime(iso) {
+    return new Date(iso).toLocaleString('pt-BR');
+}
+
+function shortDate(iso) {
+    return new Date(iso).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' });
+}
+
+function labelType(type) {
+    return {
+        meal: 'Refeição',
+        weight: 'Peso',
+        water: 'Água',
+    }[type] || type;
+}
+
+function toBase64(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+    });
+}

--- a/style.css
+++ b/style.css
@@ -1,61 +1,174 @@
+:root {
+    --bg: #f4f7fb;
+    --card: #ffffff;
+    --primary: #2563eb;
+    --text: #0f172a;
+    --muted: #64748b;
+    --border: #e2e8f0;
+}
+
+* {
+    box-sizing: border-box;
+}
+
 body {
-    font-family: Arial, sans-serif;
-    background-color: #ece5dd;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
     margin: 0;
+    font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+    background: var(--bg);
+    color: var(--text);
 }
 
-.chat {
-    width: 360px;
-    background-color: #fff;
-    border: 1px solid #ddd;
-    border-radius: 5px;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-    display: flex;
-    flex-direction: column;
+.container {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 1.2rem;
+    display: grid;
+    gap: 1rem;
 }
 
-.messages {
-    padding: 10px;
-    height: 400px;
-    overflow-y: auto;
-    display: flex;
-    flex-direction: column;
+.hero h1 {
+    margin: 0;
+    font-size: 2rem;
 }
 
-.message {
-    padding: 8px 12px;
-    margin-bottom: 8px;
-    border-radius: 5px;
-    max-width: 80%;
+.hero p {
+    color: var(--muted);
+    margin: 0.4rem 0 0;
 }
 
-.sender {
-    align-self: flex-start;
-    background-color: #e1ffc7;
+.card {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1rem;
 }
 
-.user {
-    align-self: flex-end;
-    background-color: #dcf8c6;
+.grid-two {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-#nextButton {
+.grid-three {
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.stack {
+    display: grid;
+    gap: 0.5rem;
+}
+
+input,
+button {
     width: 100%;
-    padding: 10px;
-    border: none;
-    background-color: #128C7E;
-    color: #fff;
-    font-size: 16px;
-    cursor: pointer;
-    border-bottom-left-radius: 5px;
-    border-bottom-right-radius: 5px;
+    padding: 0.65rem;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+    font: inherit;
 }
 
-#nextButton:disabled {
-    background-color: #9e9e9e;
-    cursor: not-allowed;
+button {
+    background: var(--primary);
+    color: #fff;
+    border: none;
+    cursor: pointer;
+}
+
+button:hover {
+    opacity: 0.95;
+}
+
+small,
+.muted {
+    color: var(--muted);
+}
+
+.info {
+    margin-top: 0.7rem;
+    color: #0f766e;
+    min-height: 1.2rem;
+}
+
+.stats {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.8rem;
+    margin-bottom: 1rem;
+}
+
+.stat-box {
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 0.8rem;
+    background: #f8fafc;
+}
+
+.stat-box strong {
+    display: block;
+    font-size: 1.2rem;
+    margin-top: 0.35rem;
+}
+
+.bars {
+    display: grid;
+    gap: 0.45rem;
+}
+
+.bar-row {
+    display: grid;
+    grid-template-columns: 120px 1fr 60px;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.88rem;
+}
+
+.bar {
+    height: 10px;
+    background: #dbeafe;
+    border-radius: 999px;
+    overflow: hidden;
+}
+
+.bar-fill {
+    height: 100%;
+    background: var(--primary);
+}
+
+.table-wrapper {
+    overflow-x: auto;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 0.6rem;
+}
+
+th,
+td {
+    padding: 0.6rem;
+    border-bottom: 1px solid var(--border);
+    text-align: left;
+    font-size: 0.92rem;
+}
+
+.delete-btn {
+    background: #ef4444;
+    padding: 0.35rem 0.5rem;
+    border-radius: 6px;
+    width: auto;
+}
+
+@media (max-width: 900px) {
+    .grid-two,
+    .grid-three,
+    .stats {
+        grid-template-columns: 1fr;
+    }
+
+    .bar-row {
+        grid-template-columns: 95px 1fr 50px;
+    }
 }


### PR DESCRIPTION
### Motivation
- Substituir a interface de chat por um dashboard que permita registrar refeições por foto (estimativa de calorias por IA), registrar peso e ingestão de água, e manter tudo em uma única planilha local para gerar relatórios de progresso.
- Fornecer uma solução embarcada simples (sem servidor) que persista dados no navegador e mostre visualmente agregações por dia/semana/mês e progresso de peso.

### Description
- Substitui a UI antiga por um novo layout em `index.html` com seções para `Configuração de IA`, `Registro de Refeição` (foto + calorias manuais), `Registro de Peso`, `Registro de Água`, `Relatórios` e `Planilha Única` (tabela de registros).
- Implementa estilos responsivos em `style.css` com cards, grids e gráficos de barras simples para os relatórios.
- Adiciona a lógica em `script.js` para manter uma única estrutura `records` persistida em `localStorage`, com CRUD (inserir, listar, excluir), ordenação e renderização da tabela e painéis de estatísticas.
- Integra análise de imagem usando o endpoint `https://api.openai.com/v1/responses` (modelo `gpt-4.1-mini`) enviando a imagem em base64 e preenchendo automaticamente o campo de calorias quando a IA retorna um número.
- Calcula e renderiza relatórios agregados de calorias por `day`/`week`/`month` e série de peso, usando funções como `aggregateCaloriesByPeriod`, `weightSeries` e `renderBars`.

### Testing
- Verificação estática do JS com `node --check script.js` executada com sucesso.
- Servidor local de verificação visual iniciado com `python3 -m http.server 4173` e interface capturada via Playwright (screenshot gerada) com sucesso.
- O fluxo de gravação/leitura em `localStorage`, renderização da tabela e exclusão foram validados manualmente durante a inspeção visual (sem testes automatizados adicionais).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69841b0e99ac8333bbd4288a3f24d9d4)